### PR TITLE
Fix: type WGS2GCJ has been deleted

### DIFF
--- a/geohey_toolbox_provider.py
+++ b/geohey_toolbox_provider.py
@@ -49,7 +49,7 @@ class GeoHeyToolboxProvider(QgsProcessingProvider):
         QgsProcessingProvider.__init__(self)
 
         # Load algorithms
-        self.alglist = [WGS2GCJ(), GCJ2WGS(),  GCJ2BD(), BD2GCJ(), WGS2BD(), BD2WGS()]
+        self.alglist = [WGS2GCJ, GCJ2WGS, GCJ2BD, BD2GCJ, WGS2BD, BD2WGS]
 
     def unload(self):
         """
@@ -63,7 +63,7 @@ class GeoHeyToolboxProvider(QgsProcessingProvider):
         Loads all algorithms belonging to this provider.
         """
         for alg in self.alglist:
-            self.addAlgorithm( alg )
+            self.addAlgorithm( alg() )
 
     def id(self):
         """


### PR DESCRIPTION
Fix #7 :

“wrapped C/C++ object of type WGS2GCJ has been deleted” 
这个报错不是算法运行时产生的，而是更改QGIS设置项后，重新加载算法时出现的。

报错的复现步骤:

QGIS设置>选项 打开设置窗口,
点击ok关闭选项窗口,此时会产生报错
